### PR TITLE
[WIP] fix: relpath test correctly handles different OS separator

### DIFF
--- a/resource-server-core/src/test/java/org/jasig/resource/aggr/RelativePathTest.java
+++ b/resource-server-core/src/test/java/org/jasig/resource/aggr/RelativePathTest.java
@@ -33,8 +33,8 @@ public class RelativePathTest {
     @Test
     public void resolveRelativePath() throws Exception {
         String tempPath = System.getProperty("java.io.tmpdir");
-        if(!tempPath.endsWith("/")) {
-            tempPath += "/";
+        if(!tempPath.endsWith(File.separator)) {
+            tempPath += File.separator;
         }
         
         final File tempDir = new File(new File(tempPath), "relative-path");
@@ -45,6 +45,10 @@ public class RelativePathTest {
         
         final String relativePath = RelativePath.getRelativePath(baseDir, destDir);
         
-        assertEquals("../../e/f", relativePath);
+        final String testPath = ".." + File.separator
+                              + ".." + File.separator
+                              + "e" + File.separator
+                              + "f";
+        assertEquals(testPath, relativePath);
     }
 }

--- a/resource-server-core/src/test/java/org/jasig/resource/aggr/RelativePathTest.java
+++ b/resource-server-core/src/test/java/org/jasig/resource/aggr/RelativePathTest.java
@@ -45,10 +45,8 @@ public class RelativePathTest {
         
         final String relativePath = RelativePath.getRelativePath(baseDir, destDir);
         
-        final String testPath = ".." + File.separator
-                              + ".." + File.separator
-                              + "e" + File.separator
-                              + "f";
+        final String linuxTestPath = "../../e/f";
+        final String testPath = linuxTestPath.replace("/", File.separator);
         assertEquals(testPath, relativePath);
     }
 }

--- a/resource-server-core/src/test/java/org/jasig/resource/aggr/ResourcesAggregatorImplTest.java
+++ b/resource-server-core/src/test/java/org/jasig/resource/aggr/ResourcesAggregatorImplTest.java
@@ -65,7 +65,7 @@ public class ResourcesAggregatorImplTest {
 		Diff d = new Diff(
 		        new FileReader(new ClassPathResource("skin-test1/skin.aggr.xml").getFile()),
 		        new FileReader(new File(outputDirectory, "skin.aggr.xml")));
-        assertTrue(d.toString(), d.similar());
+        assertTrue(d.toString().replace("/", File.separator), d.similar());
 	}
 
 	@Test
@@ -85,7 +85,7 @@ public class ResourcesAggregatorImplTest {
 		Diff d = new Diff(
                 new FileReader(new ClassPathResource("skin-testAllAbsolute/skin.aggr.xml").getFile()),
                 new FileReader(new File(outputDirectory, "skin.aggr.xml")));
-        assertTrue(d.toString(), d.similar());
+        assertTrue(d.toString().replace("/", File.separator), d.similar());
 	}
 
 	@Test
@@ -105,7 +105,7 @@ public class ResourcesAggregatorImplTest {
         Diff d = new Diff(
                 new FileReader(new ClassPathResource("skin-complex/superskin/skin.aggr.xml").getFile()),
                 new FileReader(new File(outputDirectory, "skin.aggr.xml")));
-        assertTrue(d.toString(), d.similar());
+        assertTrue(d.toString().replace("/", File.separator), d.similar());
 	}
 
     @Test
@@ -131,7 +131,7 @@ public class ResourcesAggregatorImplTest {
         Diff d = new Diff(
                 new FileReader(new ClassPathResource("skin-test-incl-overlay/skin.aggr.xml").getFile()),
                 new FileReader(new File(outputDirectory, "skin.aggr.xml")));
-        assertTrue(d.toString(), d.similar());
+        assertTrue(d.toString().replace("/", File.separator), d.similar());
     }
 
     @Test(expected=IOException.class)


### PR DESCRIPTION
Test was failing on Windows VM causing all PRs to fail

Resolves #185 