### PR TITLE
UPSE-293: updates to support Java 11

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,13 +28,16 @@ on:
 
 jobs:
   test:
-    name: '${{ matrix.platform }} with Java 8'
+    name: '${{ matrix.platform }} with Java ${{ matrix.java-version }}'
     strategy:
       matrix:
         platform:
           - ubuntu-latest
           - windows-latest
           - macos-latest
+        java-version:
+          - 8
+          - 11
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout
@@ -43,6 +46,6 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: adopt-hotspot
-          java-version: 8
+          java-version: ${{ matrix.java-version }}
       - name: Build and Test
         run: mvn -B package

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,8 @@
         <project.build.targetVersion>1.8</project.build.targetVersion>
 
         <jaxb2basicsVersion>0.12.0</jaxb2basicsVersion>
+        <jaxb-api.version>2.3.1</jaxb-api.version>
+        <jaxb-impl.version>2.3.3</jaxb-impl.version>
         <springVersion>5.3.15</springVersion>
     </properties>
 
@@ -65,7 +67,7 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.4.4</version>
+		<version>1.2.11</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
@@ -113,6 +115,16 @@
                 <artifactId>javax.servlet-api</artifactId>
                 <version>3.1.0</version>
                 <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>${jaxb-impl.version}</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-		<version>1.2.11</version>
+		<version>1.3.5</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/resource-server-api/pom.xml
+++ b/resource-server-api/pom.xml
@@ -55,6 +55,14 @@
             <groupId>org.jvnet.jaxb2_commons</groupId>
             <artifactId>jaxb2-basics-runtime</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+        </dependency>
         
         <dependency>
             <groupId>junit</groupId>
@@ -118,6 +126,11 @@
                         <groupId>com.sun.xml.bind</groupId>
                         <artifactId>jaxb-xjc</artifactId>
                         <version>2.2.6</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>javax.activation</groupId>
+                        <artifactId>javax.activation-api</artifactId>
+                        <version>1.2.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/resource-server-webapp/pom.xml
+++ b/resource-server-webapp/pom.xml
@@ -44,6 +44,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
+                <jaxb-api.version>2.3.1</jaxb-api.version>
+                <jaxb-impl.version>2.3.3</jaxb-impl.version>
 	</properties>
 
 	<distributionManagement>
@@ -88,6 +90,16 @@
 			<groupId>${project.groupId}</groupId>
 			<artifactId>resource-server-utils</artifactId>
 			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>${jaxb-api.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-impl</artifactId>
+			<version>${jaxb-impl.version}</version>
 		</dependency>
         <!--
          | Allows resources in webjars to be included without their version numbers;
@@ -158,7 +170,7 @@
 				<executions>
 					<execution>
 						<id>sign-artifacts</id>
-						<phase>verify</phase>
+						<phase>deploy</phase>
 						<goals>
 							<goal>sign</goal>
 						</goals>

--- a/resource-server-webapp/src/main/resources/logback.xml
+++ b/resource-server-webapp/src/main/resources/logback.xml
@@ -27,7 +27,7 @@
 <!--    http://www.qos.ch/shop/products/professionalSupport         -->
 <!--                                                                -->
 <configuration scan="true" scanPeriod="30 seconds">
-  <contextName>ResourceServingWebapp</contextName>
+  <contextName>resource-server</contextName>
 
   <!-- 
    | Propagate log levels to java.util.logging 


### PR DESCRIPTION
Added JAXB dependencies for Java 11.
Downgraded Logback version to one that runs with Java 8 (tricky: runtime error only -- no compile error).