### PR TITLE
fix: change phase back to verify to create .asc files

### DIFF
--- a/resource-server-webapp/pom.xml
+++ b/resource-server-webapp/pom.xml
@@ -170,7 +170,7 @@
         <executions>
           <execution>
             <id>sign-artifacts</id>
-            <phase>deploy</phase>
+            <phase>verify</phase>
             <goals>
               <goal>sign</goal>
             </goals>


### PR DESCRIPTION
Deployment failed due to missing .asc files for webapp files. Reverting the phase that GPG plugin had fixes the issue.