### PR TITLE
Removed plugin output directory configuration

### DIFF
--- a/resource-server-plugin/pom.xml
+++ b/resource-server-plugin/pom.xml
@@ -74,7 +74,6 @@
           <version>3.15.0</version>
           <configuration>
             <goalPrefix>plugin</goalPrefix>
-            <outputDirectory>target/dir</outputDirectory>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
The maven-plugin-plugin configuration was causing the output to be placed in a location that was not being included when the project was built. This resulted in other projects that depend on resource-server-plugin to fail to build due to a missing plugin.xml. Leaving it at it's default location causes the output to live in classes/META-INF/maven, which gets picked up properly when the jar is created.